### PR TITLE
Fix/jetpack stuff

### DIFF
--- a/mu-plugins/pwcc-helpers/inc/jetpack-fixes/namespace.php
+++ b/mu-plugins/pwcc-helpers/inc/jetpack-fixes/namespace.php
@@ -17,4 +17,37 @@ use Jetpack;
  * Runs on the `plugins_loaded` hook.
  */
 function bootstrap() {
+	add_filter( 'jetpack_implode_frontend_css', __NAMESPACE__ . '\\maybe_implode_css' );
+}
+
+/**
+ * Use a bit of smarts to determine if Jetpack CSS should be imploded.
+ *
+ * Runs on the filter `jetpack_implode_frontend_css`.
+ *
+ * @param bool $do_implode Initial decision to implode/not implode CSS.
+ * @return bool Whether to implode CSS.
+ */
+function maybe_implode_css( bool $do_implode ) {
+	if ( ! $do_implode ) {
+		// It's already been decided not to implode.
+		return $do_implode;
+	}
+
+	$jetpack = Jetpack::init();
+	$jetpack_styles = $jetpack->concatenated_style_handles;
+	$enqueued_count = 0;
+
+	foreach ( $jetpack_styles as $style ) {
+		if ( wp_style_is( $style, 'enqueued' ) ) {
+			$enqueued_count++;
+		}
+
+		if ( $enqueued_count >= 2 ) {
+			// Two or more files enqueued, no further checks required.
+			break;
+		}
+	}
+
+	return $enqueued_count >= 2 ? $do_implode : false;
 }

--- a/mu-plugins/pwcc-helpers/inc/jetpack-fixes/namespace.php
+++ b/mu-plugins/pwcc-helpers/inc/jetpack-fixes/namespace.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * PWCC Helpers.
+ *
+ * @package     PWCC Helpers
+ * @author      Peter Wilson
+ * @copyright   2018 Peter Wilson
+ * @license     GPL-2.0+
+ */
+namespace PWCC\Helpers\JetpackFixes;
+
+use Jetpack;
+
+/**
+ * Bootstrap Jetpack Fixes.
+ *
+ * Runs on the `plugins_loaded` hook.
+ */
+function bootstrap() {
+}

--- a/mu-plugins/pwcc-helpers/inc/namespace.php
+++ b/mu-plugins/pwcc-helpers/inc/namespace.php
@@ -24,6 +24,8 @@ function fast_bootstrap() {
  * Runs on the `plugins_loaded` hook.
  */
 function bootstrap() {
+	JetpackFixes\bootstrap();
+
 	// Do not resize on uploads, we use Tachyon.
 	add_filter( 'intermediate_image_sizes_advanced', __NAMESPACE__ . '\\intermediate_image_sizes' );
 }

--- a/mu-plugins/pwcc-helpers/plugin.php
+++ b/mu-plugins/pwcc-helpers/plugin.php
@@ -21,6 +21,7 @@
 namespace PWCC\Helpers;
 
 require_once __DIR__ . '/inc/namespace.php';
+require_once __DIR__ . '/inc/jetpack-fixes/namespace.php';
 
 fast_bootstrap();
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\bootstrap' );


### PR DESCRIPTION
Removes Jetpack's concatenated CSS file from the HTML header if no or one Jetpack files are enqueued.
